### PR TITLE
Render 'true' as a boolean, not as a string ('false' was already rendered correctly).

### DIFF
--- a/helpers/map_to_yaml.rb
+++ b/helpers/map_to_yaml.rb
@@ -16,7 +16,7 @@ require "json"
 require "yaml"
 
 root = JSON.parse(
-  JSON.parse(STDIN.read)["root"].gsub('"false"', 'false')
+  JSON.parse(STDIN.read)["root"].gsub('"false"', 'false').gsub('"true"','true')
 )
 
 result = {


### PR DESCRIPTION
Fixes a minor bug in terraform-google-container-vm which prevented you from creating privileged GCE containers (you couldn't specify "privileged: true").
