### PR TITLE
Render 'true' as a boolean, not as a string ('false' was already rendered correctly).

### DIFF
--- a/helpers/map_to_yaml.rb
+++ b/helpers/map_to_yaml.rb
@@ -16,7 +16,7 @@ require "json"
 require "yaml"
 
 root = JSON.parse(
-  JSON.parse(STDIN.read)["root"].gsub('"false"', 'false')
+  JSON.parse(STDIN.read)["root"].gsub('"false"', 'false').gsub('"true"','true')
 )
 
 result = {


### PR DESCRIPTION
This fixes an issue where if you said eg.

container = { 
 securityContext {
 privileged ="true"
}
}

The "true" would be converted to a string in the generated container description, which GCE would then fail to parse correctly. This would prevent your container from starting properly. "false" was already handled correctly.

This commit substitutes true as well as false, fixing the issue.