### PR TITLE
Fix script used for copyright boilerplate verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/fixtures/**/ssh/key
 *.pyc
 test/fixtures/shared/terraform.tfvars
 .idea
+.vscode

--- a/test/boilerplate/boilerplate.Dockerfile.txt
+++ b/test/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.Makefile.txt
+++ b/test/boilerplate/boilerplate.Makefile.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.go.txt
+++ b/test/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Google LLC
+Copyright YEAR Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.py.txt
+++ b/test/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.rb.txt
+++ b/test/boilerplate/boilerplate.rb.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.sh.txt
+++ b/test/boilerplate/boilerplate.sh.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.tf.txt
+++ b/test/boilerplate/boilerplate.tf.txt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright YEAR Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.xml.txt
+++ b/test/boilerplate/boilerplate.xml.txt
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018 Google LLC
+ Copyright YEAR Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/test/boilerplate/boilerplate.yaml.txt
+++ b/test/boilerplate/boilerplate.yaml.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_verify_boilerplate.py
+++ b/test/test_verify_boilerplate.py
@@ -78,17 +78,15 @@ class AllTestCase(unittest.TestCase):
         if extension not in special_cases:
             # Invalid test cases for non-*file files (.tf|.py|.sh|.yaml|.xml..)
             invalid_header = []
-            for line in header_template:
-                if "2018" in line:
-                    invalid_header.append(line.replace('2018', 'YEAR'))
-                else:
-                    invalid_header.append(line)
             invalid_header.append(content)
             invalid_content = invalid_header
             invalid_filename = tmp_path + "invalid." + extension
             self.write_file(invalid_filename, invalid_content, False)
             valid_filename = tmp_path + "testfile." + extension
 
+        for i, line in enumerate(header_template):
+            if "YEAR" in line:
+                header_template[i] = line.replace('YEAR', '2018')
         valid_content = header_template
         self.write_file(valid_filename, valid_content, True)
 

--- a/test/verify_boilerplate.py
+++ b/test/verify_boilerplate.py
@@ -37,260 +37,260 @@ SKIPPED_DIRS = [
 
 
 def get_args():
-  """Parses command line arguments.
+    """Parses command line arguments.
 
-  Configures and runs argparse.ArgumentParser to extract command line
-  arguments.
+    Configures and runs argparse.ArgumentParser to extract command line
+    arguments.
 
-  Returns:
-      An argparse.Namespace containing the arguments parsed from the
-      command line
-  """
-  parser = argparse.ArgumentParser()
-  parser.add_argument("filenames",
-                      help="list of files to check, "
-                           "all files if unspecified",
-                      nargs='*')
-  rootdir = os.path.dirname(__file__) + "/../"
-  rootdir = os.path.abspath(rootdir)
-  parser.add_argument(
-      "--rootdir",
-      default=rootdir,
-      help="root directory to examine")
+    Returns:
+        An argparse.Namespace containing the arguments parsed from the
+        command line
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filenames",
+                        help="list of files to check, "
+                             "all files if unspecified",
+                        nargs='*')
+    rootdir = os.path.dirname(__file__) + "/../"
+    rootdir = os.path.abspath(rootdir)
+    parser.add_argument(
+        "--rootdir",
+        default=rootdir,
+        help="root directory to examine")
 
-  default_boilerplate_dir = os.path.join(rootdir, "test/boilerplate")
-  parser.add_argument("--boilerplate-dir", default=default_boilerplate_dir)
-  return parser.parse_args()
+    default_boilerplate_dir = os.path.join(rootdir, "test/boilerplate")
+    parser.add_argument("--boilerplate-dir", default=default_boilerplate_dir)
+    return parser.parse_args()
 
 
 def get_refs(ARGS):
-  """Converts the directory of boilerplate files into a map keyed by file
-  extension.
+    """Converts the directory of boilerplate files into a map keyed by file
+    extension.
 
-  Reads each boilerplate file's contents into an array, then adds that array
-  to a map keyed by the file extension.
+    Reads each boilerplate file's contents into an array, then adds that array
+    to a map keyed by the file extension.
 
-  Returns:
-      A map of boilerplate lines, keyed by file extension. For example,
-      boilerplate.py.txt would result in the k,v pair {".py": py_lines} where
-      py_lines is an array containing each line of the file.
-  """
-  refs = {}
+    Returns:
+        A map of boilerplate lines, keyed by file extension. For example,
+        boilerplate.py.txt would result in the k,v pair {".py": py_lines} where
+        py_lines is an array containing each line of the file.
+    """
+    refs = {}
 
-  # Find and iterate over the absolute path for each boilerplate template
-  for path in glob.glob(os.path.join(
-          ARGS.boilerplate_dir,
-          "boilerplate.*.txt")):
-    extension = os.path.basename(path).split(".")[1]
-    ref_file = open(path, 'r')
-    ref = ref_file.read().splitlines()
-    ref_file.close()
-    refs[extension] = ref
-  return refs
+    # Find and iterate over the absolute path for each boilerplate template
+    for path in glob.glob(os.path.join(
+            ARGS.boilerplate_dir,
+            "boilerplate.*.txt")):
+        extension = os.path.basename(path).split(".")[1]
+        ref_file = open(path, 'r')
+        ref = ref_file.read().splitlines()
+        ref_file.close()
+        refs[extension] = ref
+    return refs
 
 
 # pylint: disable=too-many-locals
 def has_valid_header(filename, refs, regexs):
-  """Test whether a file has the correct boilerplate header.
+    """Test whether a file has the correct boilerplate header.
 
-  Tests each file against the boilerplate stored in refs for that file type
-  (based on extension), or by the entire filename (eg Dockerfile, Makefile).
-  Some heuristics are applied to remove build tags and shebangs, but little
-  variance in header formatting is tolerated.
+    Tests each file against the boilerplate stored in refs for that file type
+    (based on extension), or by the entire filename (eg Dockerfile, Makefile).
+    Some heuristics are applied to remove build tags and shebangs, but little
+    variance in header formatting is tolerated.
 
-  Args:
-      filename: A string containing the name of the file to test
-      refs: A map of boilerplate headers, keyed by file extension
-      regexs: a map of compiled regex objects used in verifying boilerplate
+    Args:
+        filename: A string containing the name of the file to test
+        refs: A map of boilerplate headers, keyed by file extension
+        regexs: a map of compiled regex objects used in verifying boilerplate
 
-  Returns:
-      True if the file has the correct boilerplate header, otherwise returns
-      False.
-  """
-  try:
-    with open(filename, 'r') as fp:  # pylint: disable=invalid-name
-      data = fp.read()
-  except IOError:
-    return False
-  basename = os.path.basename(filename)
-  extension = get_file_extension(filename)
-  if extension:
-    ref = refs[extension]
-  else:
-    ref = refs[basename]
+    Returns:
+        True if the file has the correct boilerplate header, otherwise returns
+        False.
+    """
+    try:
+        with open(filename, 'r') as fp:  # pylint: disable=invalid-name
+            data = fp.read()
+    except IOError:
+        return False
+    basename = os.path.basename(filename)
+    extension = get_file_extension(filename)
+    if extension:
+        ref = refs[extension]
+    else:
+        ref = refs[basename]
 
-  # remove build tags from the top of Go files
-  if extension == "go":
-    data = regexs["go_build_constraints"].sub("", data)
-  # remove shebang
-  elif extension == "sh" or extension == "py":
-    data = regexs["shebang"].sub("", data)
-  # normalize cloud-init files
-  elif basename in ("cloud-init.yaml", "cloud-config.yaml"):
-    data = regexs["cloud-init"].sub("", data)
+    # remove build tags from the top of Go files
+    if extension == "go":
+        data = regexs["go_build_constraints"].sub("", data)
+    # remove shebang
+    elif extension == "sh" or extension == "py":
+        data = regexs["shebang"].sub("", data)
+    # normalize cloud-init files
+    elif basename in ("cloud-init.yaml", "cloud-config.yaml"):
+        data = regexs["cloud-init"].sub("", data)
 
-  # look for 'YEAR' string, and fail if found
-  if regexs["year"].match(data):
-    print("year fail %s" % basename)
-    return False
+    # look for 'YEAR' string, and fail if found
+    if regexs["year"].match(data):
+        print("year fail %s" % basename)
+        return False
 
-  # replace actual year with 'YEAR' string
-  data = regexs["years"].sub("YEAR", data)
+    # replace actual year with 'YEAR' string
+    data = regexs["years"].sub("YEAR", data)
 
-  data = data.splitlines()
-  # if our test file is smaller than the reference it surely fails!
-  if len(ref) > len(data):
-    print("length fail %s" % basename)
-    return False
+    data = data.splitlines()
+    # if our test file is smaller than the reference it surely fails!
+    if len(ref) > len(data):
+        print("length fail %s" % basename)
+        return False
 
-  # trim our file to the same number of lines as the reference file
-  data = data[:len(ref)]
+    # trim our file to the same number of lines as the reference file
+    data = data[:len(ref)]
 
-  # if we don't match the reference at this point, fail
-  if ref != data:
-    print("data fail %s" % basename)
-    return False
+    # if we don't match the reference at this point, fail
+    if ref != data:
+        print("data fail %s" % basename)
+        return False
 
-  return True
+    return True
 
 
 def get_file_extension(filename):
-  """Extracts the extension part of a filename.
+    """Extracts the extension part of a filename.
 
-  Identifies the extension as everything after the last period in filename.
+    Identifies the extension as everything after the last period in filename.
 
-  Args:
-      filename: string containing the filename
+    Args:
+        filename: string containing the filename
 
-  Returns:
-      A string containing the extension in lowercase
-  """
-  return os.path.splitext(filename)[1].split(".")[-1].lower()
+    Returns:
+        A string containing the extension in lowercase
+    """
+    return os.path.splitext(filename)[1].split(".")[-1].lower()
 
 
 def normalize_files(files):
-  """Extracts the files that require boilerplate checking from the files
-  argument.
+    """Extracts the files that require boilerplate checking from the files
+    argument.
 
-  A new list will be built. Each path from the original files argument will
-  be added unless it is within one of SKIPPED_DIRS. All relative paths will
-  be converted to absolute paths by prepending the root_dir path parsed from
-  the command line, or its default value.
+    A new list will be built. Each path from the original files argument will
+    be added unless it is within one of SKIPPED_DIRS. All relative paths will
+    be converted to absolute paths by prepending the root_dir path parsed from
+    the command line, or its default value.
 
-  Args:
-      files: a list of file path strings
+    Args:
+        files: a list of file path strings
 
-  Returns:
-      A modified copy of the files list where any any path in a skipped
-      directory is removed, and all paths have been made absolute.
-  """
-  newfiles = []
-  for pathname in files:
-    if any(x in pathname for x in SKIPPED_DIRS):
-      continue
-    newfiles.append(pathname)
-  for idx, pathname in enumerate(newfiles):
-    if not os.path.isabs(pathname):
-      newfiles[idx] = os.path.join(ARGS.rootdir, pathname)
-  return newfiles
+    Returns:
+        A modified copy of the files list where any any path in a skipped
+        directory is removed, and all paths have been made absolute.
+    """
+    newfiles = []
+    for pathname in files:
+        if any(x in pathname for x in SKIPPED_DIRS):
+            continue
+        newfiles.append(pathname)
+    for idx, pathname in enumerate(newfiles):
+        if not os.path.isabs(pathname):
+            newfiles[idx] = os.path.join(ARGS.rootdir, pathname)
+    return newfiles
 
 
 def get_files(extensions, ARGS):
-  """Generates a list of paths whose boilerplate should be verified.
+    """Generates a list of paths whose boilerplate should be verified.
 
-  If a list of file names has been provided on the command line, it will be
-  treated as the initial set to search. Otherwise, all paths within rootdir
-  will be discovered and used as the initial set.
+    If a list of file names has been provided on the command line, it will be
+    treated as the initial set to search. Otherwise, all paths within rootdir
+    will be discovered and used as the initial set.
 
-  Once the initial set of files is identified, it is normalized via
-  normalize_files() and further stripped of any file name whose extension is
-  not in extensions.
+    Once the initial set of files is identified, it is normalized via
+    normalize_files() and further stripped of any file name whose extension is
+    not in extensions.
 
-  Args:
-      extensions: a list of file extensions indicating which file types
-                  should have their boilerplate verified
+    Args:
+        extensions: a list of file extensions indicating which file types
+                    should have their boilerplate verified
 
-  Returns:
-      A list of absolute file paths
-  """
-  files = []
-  if ARGS.filenames:
-    files = ARGS.filenames
-  else:
-    for root, dirs, walkfiles in os.walk(ARGS.rootdir):
-      # don't visit certain dirs. This is just a performance improvement
-      # as we would prune these later in normalize_files(). But doing it
-      # cuts down the amount of filesystem walking we do and cuts down
-      # the size of the file list
-      for dpath in SKIPPED_DIRS:
-        if dpath in dirs:
-          dirs.remove(dpath)
-      for name in walkfiles:
-        pathname = os.path.join(root, name)
-        files.append(pathname)
-  files = normalize_files(files)
-  outfiles = []
-  for pathname in files:
-    basename = os.path.basename(pathname)
-    extension = get_file_extension(pathname)
-    if extension in extensions or basename in extensions:
-      outfiles.append(pathname)
-  return outfiles
+    Returns:
+        A list of absolute file paths
+    """
+    files = []
+    if ARGS.filenames:
+        files = ARGS.filenames
+    else:
+        for root, dirs, walkfiles in os.walk(ARGS.rootdir):
+            # don't visit certain dirs. This is just a performance improvement
+            # as we would prune these later in normalize_files(). But doing it
+            # cuts down the amount of filesystem walking we do and cuts down
+            # the size of the file list
+            for dpath in SKIPPED_DIRS:
+                if dpath in dirs:
+                    dirs.remove(dpath)
+            for name in walkfiles:
+                pathname = os.path.join(root, name)
+                files.append(pathname)
+    files = normalize_files(files)
+    outfiles = []
+    for pathname in files:
+        basename = os.path.basename(pathname)
+        extension = get_file_extension(pathname)
+        if extension in extensions or basename in extensions:
+            outfiles.append(pathname)
+    return outfiles
 
 
 def get_regexs():
-  """Builds a map of regular expressions used in boilerplate validation.
+    """Builds a map of regular expressions used in boilerplate validation.
 
-  There are two scenarios where these regexes are used. The first is in
-  validating the date referenced is the boilerplate, by ensuring it is an
-  acceptable year. The second is in identifying non-boilerplate elements,
-  like shebangs and compiler hints that should be ignored when validating
-  headers.
+    There are two scenarios where these regexes are used. The first is in
+    validating the date referenced is the boilerplate, by ensuring it is an
+    acceptable year. The second is in identifying non-boilerplate elements,
+    like shebangs and compiler hints that should be ignored when validating
+    headers.
 
-  Returns:
-      A map of compiled regular expression objects, keyed by mnemonic.
-  """
-  regexs = {}
-  # Search for "YEAR" which exists in the boilerplate, but shouldn't in the
-  # real thing
-  regexs["year"] = re.compile('^# Copyright YEAR')
-  # dates can be 2014, 2015, 2016 or 2017, company holder names can be
-  # anything
-  regexs["years"] = re.compile(r"(%s)" % "|".join(
-      str(s) for s in range(2014, int(time.strftime("%Y")) + 1)))
-  # strip // +build \n\n build constraints
-  regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n",
-                                              re.MULTILINE)
-  # strip #!.* from shell/python scripts
-  regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
-  # remove top-level cloud-config comment from cloud-init yaml files
-  regexs["cloud-init"] = re.compile(r"^#cloud-config\s*", re.DOTALL)
-  return regexs
+    Returns:
+        A map of compiled regular expression objects, keyed by mnemonic.
+    """
+    regexs = {}
+    # Search for "YEAR" which exists in the boilerplate, but shouldn't in the
+    # real thing
+    regexs["year"] = re.compile('^# Copyright YEAR')
+    # dates can be 2014, 2015, 2016 or 2017, company holder names can be
+    # anything
+    regexs["years"] = re.compile(r"(%s)" % "|".join(
+        str(s) for s in range(2014, int(time.strftime("%Y")) + 1)))
+    # strip // +build \n\n build constraints
+    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n",
+                                                re.MULTILINE)
+    # strip #!.* from shell/python scripts
+    regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
+    # remove top-level cloud-config comment from cloud-init yaml files
+    regexs["cloud-init"] = re.compile(r"^#cloud-config\s*", re.DOTALL)
+    return regexs
 
 
 def main(args):
-  """Identifies and verifies files that should have the desired boilerplate.
+    """Identifies and verifies files that should have the desired boilerplate.
 
-  Retrieves the lists of files to be validated and tests each one in turn.
-  If all files contain correct boilerplate, this function terminates
-  normally. Otherwise it prints the name of each non-conforming file and
-  exists with a non-zero status code.
-  """
-  regexs = get_regexs()
-  refs = get_refs(args)
-  filenames = get_files(refs.keys(), args)
-  nonconforming_files = []
-  for filename in filenames:
-    if not has_valid_header(filename, refs, regexs):
-      nonconforming_files.append(filename)
-  if nonconforming_files:
-    print('%d files have incorrect boilerplate headers:' % len(
-        nonconforming_files))
-    for filename in sorted(nonconforming_files):
-      print(os.path.relpath(filename, args.rootdir))
-    sys.exit(1)
+    Retrieves the lists of files to be validated and tests each one in turn.
+    If all files contain correct boilerplate, this function terminates
+    normally. Otherwise it prints the name of each non-conforming file and
+    exists with a non-zero status code.
+    """
+    regexs = get_regexs()
+    refs = get_refs(args)
+    filenames = get_files(refs.keys(), args)
+    nonconforming_files = []
+    for filename in filenames:
+        if not has_valid_header(filename, refs, regexs):
+            nonconforming_files.append(filename)
+    if nonconforming_files:
+        print('%d files have incorrect boilerplate headers:' % len(
+            nonconforming_files))
+        for filename in sorted(nonconforming_files):
+            print(os.path.relpath(filename, args.rootdir))
+        sys.exit(1)
 
 
 if __name__ == "__main__":
-  ARGS = get_args()
-  main(ARGS)
+    ARGS = get_args()
+    main(ARGS)

--- a/test/verify_boilerplate.py
+++ b/test/verify_boilerplate.py
@@ -18,133 +18,15 @@
 # This is based on existing work
 # https://github.com/kubernetes/test-infra/blob/master/hack
 # /verify_boilerplate.py
+
 from __future__ import print_function
+
 import argparse
 import glob
 import os
 import re
 import sys
-
-
-def get_args():
-    """Parses command line arguments.
-
-    Configures and runs argparse.ArgumentParser to extract command line
-    arguments.
-
-    Returns:
-        An argparse.Namespace containing the arguments parsed from the
-        command line
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_argument("filenames",
-                        help="list of files to check, "
-                             "all files if unspecified",
-                        nargs='*')
-    rootdir = os.path.dirname(__file__) + "/../"
-    rootdir = os.path.abspath(rootdir)
-    parser.add_argument(
-        "--rootdir",
-        default=rootdir,
-        help="root directory to examine")
-
-    default_boilerplate_dir = os.path.join(rootdir, "test/boilerplate")
-    parser.add_argument("--boilerplate-dir", default=default_boilerplate_dir)
-    return parser.parse_args()
-
-
-def get_refs(ARGS):
-    """Converts the directory of boilerplate files into a map keyed by file
-    extension.
-
-    Reads each boilerplate file's contents into an array, then adds that array
-    to a map keyed by the file extension.
-
-    Returns:
-        A map of boilerplate lines, keyed by file extension. For example,
-        boilerplate.py.txt would result in the k,v pair {".py": py_lines} where
-        py_lines is an array containing each line of the file.
-    """
-    refs = {}
-
-    # Find and iterate over the absolute path for each boilerplate template
-    for path in glob.glob(os.path.join(
-            ARGS.boilerplate_dir,
-            "boilerplate.*.txt")):
-        extension = os.path.basename(path).split(".")[1]
-        ref_file = open(path, 'r')
-        ref = ref_file.read().splitlines()
-        ref_file.close()
-        refs[extension] = ref
-    return refs
-
-
-# pylint: disable=too-many-locals
-def has_valid_header(filename, refs, regexs):
-    """Test whether a file has the correct boilerplate header.
-
-    Tests each file against the boilerplate stored in refs for that file type
-    (based on extension), or by the entire filename (eg Dockerfile, Makefile).
-    Some heuristics are applied to remove build tags and shebangs, but little
-    variance in header formatting is tolerated.
-
-    Args:
-        filename: A string containing the name of the file to test
-        refs: A map of boilerplate headers, keyed by file extension
-        regexs: a map of compiled regex objects used in verifying boilerplate
-
-    Returns:
-        True if the file has the correct boilerplate header, otherwise returns
-        False.
-    """
-    try:
-        with open(filename, 'r') as fp:  # pylint: disable=invalid-name
-            data = fp.read()
-    except IOError:
-        return False
-    basename = os.path.basename(filename)
-    extension = get_file_extension(filename)
-    if extension:
-        ref = refs[extension]
-    else:
-        ref = refs[basename]
-    # remove build tags from the top of Go files
-    if extension == "go":
-        con = regexs["go_build_constraints"]
-        (data, found) = con.subn("", data, 1)
-    # remove shebang
-    elif extension == "sh" or extension == "py":
-        she = regexs["shebang"]
-        (data, found) = she.subn("", data, 1)
-    data = data.splitlines()
-    # if our test file is smaller than the reference it surely fails!
-    if len(ref) > len(data):
-        return False
-    # trim our file to the same number of lines as the reference file
-    data = data[:len(ref)]
-    year = regexs["year"]
-    for datum in data:
-        if year.search(datum):
-            return False
-
-    # if we don't match the reference at this point, fail
-    if ref != data:
-        return False
-    return True
-
-
-def get_file_extension(filename):
-    """Extracts the extension part of a filename.
-
-    Identifies the extension as everything after the last period in filename.
-
-    Args:
-        filename: string containing the filename
-
-    Returns:
-        A string containing the extension in lowercase
-    """
-    return os.path.splitext(filename)[1].split(".")[-1].lower()
+import time
 
 
 # These directories will be omitted from header checks
@@ -154,126 +36,261 @@ SKIPPED_DIRS = [
 ]
 
 
+def get_args():
+  """Parses command line arguments.
+
+  Configures and runs argparse.ArgumentParser to extract command line
+  arguments.
+
+  Returns:
+      An argparse.Namespace containing the arguments parsed from the
+      command line
+  """
+  parser = argparse.ArgumentParser()
+  parser.add_argument("filenames",
+                      help="list of files to check, "
+                           "all files if unspecified",
+                      nargs='*')
+  rootdir = os.path.dirname(__file__) + "/../"
+  rootdir = os.path.abspath(rootdir)
+  parser.add_argument(
+      "--rootdir",
+      default=rootdir,
+      help="root directory to examine")
+
+  default_boilerplate_dir = os.path.join(rootdir, "test/boilerplate")
+  parser.add_argument("--boilerplate-dir", default=default_boilerplate_dir)
+  return parser.parse_args()
+
+
+def get_refs(ARGS):
+  """Converts the directory of boilerplate files into a map keyed by file
+  extension.
+
+  Reads each boilerplate file's contents into an array, then adds that array
+  to a map keyed by the file extension.
+
+  Returns:
+      A map of boilerplate lines, keyed by file extension. For example,
+      boilerplate.py.txt would result in the k,v pair {".py": py_lines} where
+      py_lines is an array containing each line of the file.
+  """
+  refs = {}
+
+  # Find and iterate over the absolute path for each boilerplate template
+  for path in glob.glob(os.path.join(
+          ARGS.boilerplate_dir,
+          "boilerplate.*.txt")):
+    extension = os.path.basename(path).split(".")[1]
+    ref_file = open(path, 'r')
+    ref = ref_file.read().splitlines()
+    ref_file.close()
+    refs[extension] = ref
+  return refs
+
+
+# pylint: disable=too-many-locals
+def has_valid_header(filename, refs, regexs):
+  """Test whether a file has the correct boilerplate header.
+
+  Tests each file against the boilerplate stored in refs for that file type
+  (based on extension), or by the entire filename (eg Dockerfile, Makefile).
+  Some heuristics are applied to remove build tags and shebangs, but little
+  variance in header formatting is tolerated.
+
+  Args:
+      filename: A string containing the name of the file to test
+      refs: A map of boilerplate headers, keyed by file extension
+      regexs: a map of compiled regex objects used in verifying boilerplate
+
+  Returns:
+      True if the file has the correct boilerplate header, otherwise returns
+      False.
+  """
+  try:
+    with open(filename, 'r') as fp:  # pylint: disable=invalid-name
+      data = fp.read()
+  except IOError:
+    return False
+  basename = os.path.basename(filename)
+  extension = get_file_extension(filename)
+  if extension:
+    ref = refs[extension]
+  else:
+    ref = refs[basename]
+
+  # remove build tags from the top of Go files
+  if extension == "go":
+    data = regexs["go_build_constraints"].sub("", data)
+  # remove shebang
+  elif extension == "sh" or extension == "py":
+    data = regexs["shebang"].sub("", data)
+  # normalize cloud-init files
+  elif basename in ("cloud-init.yaml", "cloud-config.yaml"):
+    data = regexs["cloud-init"].sub("", data)
+
+  # look for 'YEAR' string, and fail if found
+  if regexs["year"].match(data):
+    print("year fail %s" % basename)
+    return False
+
+  # replace actual year with 'YEAR' string
+  data = regexs["years"].sub("YEAR", data)
+
+  data = data.splitlines()
+  # if our test file is smaller than the reference it surely fails!
+  if len(ref) > len(data):
+    print("length fail %s" % basename)
+    return False
+
+  # trim our file to the same number of lines as the reference file
+  data = data[:len(ref)]
+
+  # if we don't match the reference at this point, fail
+  if ref != data:
+    print("data fail %s" % basename)
+    return False
+
+  return True
+
+
+def get_file_extension(filename):
+  """Extracts the extension part of a filename.
+
+  Identifies the extension as everything after the last period in filename.
+
+  Args:
+      filename: string containing the filename
+
+  Returns:
+      A string containing the extension in lowercase
+  """
+  return os.path.splitext(filename)[1].split(".")[-1].lower()
+
+
 def normalize_files(files):
-    """Extracts the files that require boilerplate checking from the files
-    argument.
+  """Extracts the files that require boilerplate checking from the files
+  argument.
 
-    A new list will be built. Each path from the original files argument will
-    be added unless it is within one of SKIPPED_DIRS. All relative paths will
-    be converted to absolute paths by prepending the root_dir path parsed from
-    the command line, or its default value.
+  A new list will be built. Each path from the original files argument will
+  be added unless it is within one of SKIPPED_DIRS. All relative paths will
+  be converted to absolute paths by prepending the root_dir path parsed from
+  the command line, or its default value.
 
-    Args:
-        files: a list of file path strings
+  Args:
+      files: a list of file path strings
 
-    Returns:
-        A modified copy of the files list where any any path in a skipped
-        directory is removed, and all paths have been made absolute.
-    """
-    newfiles = []
-    for pathname in files:
-        if any(x in pathname for x in SKIPPED_DIRS):
-            continue
-        newfiles.append(pathname)
-    for idx, pathname in enumerate(newfiles):
-        if not os.path.isabs(pathname):
-            newfiles[idx] = os.path.join(ARGS.rootdir, pathname)
-    return newfiles
+  Returns:
+      A modified copy of the files list where any any path in a skipped
+      directory is removed, and all paths have been made absolute.
+  """
+  newfiles = []
+  for pathname in files:
+    if any(x in pathname for x in SKIPPED_DIRS):
+      continue
+    newfiles.append(pathname)
+  for idx, pathname in enumerate(newfiles):
+    if not os.path.isabs(pathname):
+      newfiles[idx] = os.path.join(ARGS.rootdir, pathname)
+  return newfiles
 
 
 def get_files(extensions, ARGS):
-    """Generates a list of paths whose boilerplate should be verified.
+  """Generates a list of paths whose boilerplate should be verified.
 
-    If a list of file names has been provided on the command line, it will be
-    treated as the initial set to search. Otherwise, all paths within rootdir
-    will be discovered and used as the initial set.
+  If a list of file names has been provided on the command line, it will be
+  treated as the initial set to search. Otherwise, all paths within rootdir
+  will be discovered and used as the initial set.
 
-    Once the initial set of files is identified, it is normalized via
-    normalize_files() and further stripped of any file name whose extension is
-    not in extensions.
+  Once the initial set of files is identified, it is normalized via
+  normalize_files() and further stripped of any file name whose extension is
+  not in extensions.
 
-    Args:
-        extensions: a list of file extensions indicating which file types
-                    should have their boilerplate verified
+  Args:
+      extensions: a list of file extensions indicating which file types
+                  should have their boilerplate verified
 
-    Returns:
-        A list of absolute file paths
-    """
-    files = []
-    if ARGS.filenames:
-        files = ARGS.filenames
-    else:
-        for root, dirs, walkfiles in os.walk(ARGS.rootdir):
-            # don't visit certain dirs. This is just a performance improvement
-            # as we would prune these later in normalize_files(). But doing it
-            # cuts down the amount of filesystem walking we do and cuts down
-            # the size of the file list
-            for dpath in SKIPPED_DIRS:
-                if dpath in dirs:
-                    dirs.remove(dpath)
-            for name in walkfiles:
-                pathname = os.path.join(root, name)
-                files.append(pathname)
-    files = normalize_files(files)
-    outfiles = []
-    for pathname in files:
-        basename = os.path.basename(pathname)
-        extension = get_file_extension(pathname)
-        if extension in extensions or basename in extensions:
-            outfiles.append(pathname)
-    return outfiles
+  Returns:
+      A list of absolute file paths
+  """
+  files = []
+  if ARGS.filenames:
+    files = ARGS.filenames
+  else:
+    for root, dirs, walkfiles in os.walk(ARGS.rootdir):
+      # don't visit certain dirs. This is just a performance improvement
+      # as we would prune these later in normalize_files(). But doing it
+      # cuts down the amount of filesystem walking we do and cuts down
+      # the size of the file list
+      for dpath in SKIPPED_DIRS:
+        if dpath in dirs:
+          dirs.remove(dpath)
+      for name in walkfiles:
+        pathname = os.path.join(root, name)
+        files.append(pathname)
+  files = normalize_files(files)
+  outfiles = []
+  for pathname in files:
+    basename = os.path.basename(pathname)
+    extension = get_file_extension(pathname)
+    if extension in extensions or basename in extensions:
+      outfiles.append(pathname)
+  return outfiles
 
 
 def get_regexs():
-    """Builds a map of regular expressions used in boilerplate validation.
+  """Builds a map of regular expressions used in boilerplate validation.
 
-    There are two scenarios where these regexes are used. The first is in
-    validating the date referenced is the boilerplate, by ensuring it is an
-    acceptable year. The second is in identifying non-boilerplate elements,
-    like shebangs and compiler hints that should be ignored when validating
-    headers.
+  There are two scenarios where these regexes are used. The first is in
+  validating the date referenced is the boilerplate, by ensuring it is an
+  acceptable year. The second is in identifying non-boilerplate elements,
+  like shebangs and compiler hints that should be ignored when validating
+  headers.
 
-    Returns:
-        A map of compiled regular expression objects, keyed by mnemonic.
-    """
-    regexs = {}
-    # Search for "YEAR" which exists in the boilerplate, but shouldn't in the
-    # real thing
-    regexs["year"] = re.compile('YEAR')
-    # dates can be 2014, 2015, 2016 or 2017, company holder names can be
-    # anything
-    regexs["date"] = re.compile('(2014|2015|2016|2017|2018)')
-    # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n",
-                                                re.MULTILINE)
-    # strip #!.* from shell/python scripts
-    regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
-    return regexs
+  Returns:
+      A map of compiled regular expression objects, keyed by mnemonic.
+  """
+  regexs = {}
+  # Search for "YEAR" which exists in the boilerplate, but shouldn't in the
+  # real thing
+  regexs["year"] = re.compile('^# Copyright YEAR')
+  # dates can be 2014, 2015, 2016 or 2017, company holder names can be
+  # anything
+  regexs["years"] = re.compile(r"(%s)" % "|".join(
+      str(s) for s in range(2014, int(time.strftime("%Y")) + 1)))
+  # strip // +build \n\n build constraints
+  regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n",
+                                              re.MULTILINE)
+  # strip #!.* from shell/python scripts
+  regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
+  # remove top-level cloud-config comment from cloud-init yaml files
+  regexs["cloud-init"] = re.compile(r"^#cloud-config\s*", re.DOTALL)
+  return regexs
 
 
 def main(args):
-    """Identifies and verifies files that should have the desired boilerplate.
+  """Identifies and verifies files that should have the desired boilerplate.
 
-    Retrieves the lists of files to be validated and tests each one in turn.
-    If all files contain correct boilerplate, this function terminates
-    normally. Otherwise it prints the name of each non-conforming file and
-    exists with a non-zero status code.
-    """
-    regexs = get_regexs()
-    refs = get_refs(args)
-    filenames = get_files(refs.keys(), args)
-    nonconforming_files = []
-    for filename in filenames:
-        if not has_valid_header(filename, refs, regexs):
-            nonconforming_files.append(filename)
-    if nonconforming_files:
-        print('%d files have incorrect boilerplate headers:' % len(
-            nonconforming_files))
-        for filename in sorted(nonconforming_files):
-            print(os.path.relpath(filename, args.rootdir))
-        sys.exit(1)
+  Retrieves the lists of files to be validated and tests each one in turn.
+  If all files contain correct boilerplate, this function terminates
+  normally. Otherwise it prints the name of each non-conforming file and
+  exists with a non-zero status code.
+  """
+  regexs = get_regexs()
+  refs = get_refs(args)
+  filenames = get_files(refs.keys(), args)
+  nonconforming_files = []
+  for filename in filenames:
+    if not has_valid_header(filename, refs, regexs):
+      nonconforming_files.append(filename)
+  if nonconforming_files:
+    print('%d files have incorrect boilerplate headers:' % len(
+        nonconforming_files))
+    for filename in sorted(nonconforming_files):
+      print(os.path.relpath(filename, args.rootdir))
+    sys.exit(1)
 
 
 if __name__ == "__main__":
-    ARGS = get_args()
-    main(ARGS)
+  ARGS = get_args()
+  main(ARGS)

--- a/test/verify_boilerplate.py
+++ b/test/verify_boilerplate.py
@@ -131,7 +131,6 @@ def has_valid_header(filename, refs, regexs):
 
     # look for 'YEAR' string, and fail if found
     if regexs["year"].match(data):
-        print("year fail %s" % basename)
         return False
 
     # replace actual year with 'YEAR' string
@@ -140,7 +139,6 @@ def has_valid_header(filename, refs, regexs):
     data = data.splitlines()
     # if our test file is smaller than the reference it surely fails!
     if len(ref) > len(data):
-        print("length fail %s" % basename)
         return False
 
     # trim our file to the same number of lines as the reference file
@@ -148,7 +146,6 @@ def has_valid_header(filename, refs, regexs):
 
     # if we don't match the reference at this point, fail
     if ref != data:
-        print("data fail %s" % basename)
         return False
 
     return True


### PR DESCRIPTION
This implements two fixes to the verify boilerplate script:

- add proper support for year ranges in the license boilerplates, the script had initial support but it was unused and the actual functionality not implemented
- detect cloud-init files and normalize them by stripping away the top-level `#cloud-config` comment (which is needed by the cloud-init machinery on COS) before checking boilerplate

It also adds a few minimal fixes to the script, like moving constants on top of the file, and using the regexp module `sub` function instead of `subn`. A subsequent PR will add meaningful error messages to help in detecting why and where validation failed.