### PR TITLE
Migrated MIG example to TF 0.12 syntax and compatible modules

### DIFF
--- a/examples/managed_instance_group/outputs.tf
+++ b/examples/managed_instance_group/outputs.tf
@@ -19,11 +19,6 @@ output "project_id" {
   value       = var.project_id
 }
 
-output "zone" {
-  description = "The zone the GCE instance was deployed into"
-  value       = var.zone
-}
-
 output "vm_container_label" {
   description = "The instance label containing container configuration"
   value       = module.gce-container.vm_container_label

--- a/examples/managed_instance_group/variables.tf
+++ b/examples/managed_instance_group/variables.tf
@@ -16,52 +16,63 @@
 
 variable "project_id" {
   description = "The project ID to deploy resource into"
-}
-
-variable "subnetwork_project" {
-  description = "The project ID where the desired subnetwork is provisioned"
+  type        = string
 }
 
 variable "subnetwork" {
   description = "The name of the subnetwork to deploy instances into"
+  type        = string
+  default     = "mig-subnet"
 }
 
 variable "mig_name" {
   description = "The desired name to assign to the deployed managed instance group"
+  type        = string
   default     = "mig-test"
 }
 
 variable "mig_instance_count" {
   description = "The number of instances to place in the managed instance group"
+  type        = string
   default     = "2"
 }
 
 variable "image" {
   description = "The Docker image to deploy to GCE instances"
+  type        = string
+  default     = "gcr.io/google-samples/hello-app:1.0"
 }
 
 variable "image_port" {
   description = "The port the image exposes for HTTP requests"
-}
-
-variable "restart_policy" {
-  description = "The desired Docker restart policy for the deployed image"
-}
-
-variable "machine_type" {
-  description = "The GCP machine type to deploy"
+  type        = number
+  default     = 8080
 }
 
 variable "region" {
   description = "The GCP region to deploy instances into"
+  type        = string
 }
 
-variable "zone" {
-  description = "The GCP zone to deploy instances into"
+variable "network" {
+  description = "The GCP network"
+  type        = string
+  default     = "mig-net"
 }
 
 variable "additional_metadata" {
-  type        = "map"
+  type        = map
   description = "Additional metadata to attach to the instance"
   default     = {}
+}
+
+variable "service_account" {
+  type    = object({
+    email  = string,
+    scopes = list(string)
+  })
+  default = {
+    email  = ""
+    scopes = ["cloud-platform"]
+  }
 }


### PR DESCRIPTION
Fixes #28

Migrated MIG example to TF 0.12 syntax and compatible modules
- Migrated to TF 0.12 syntax
- Added provider version restrictions
- Migrated to TF 0.12 compatible modules
- Added provision of required resources:
  - network
  - subnetwork
  - router
  - cloud-nat
- Optimized tag assignment with local variable
- Added new required variables:
  - service_account
  - network

Please note: 

This PR depends on https://github.com/terraform-google-modules/terraform-google-lb-http/pull/52

TO DO (once lb-http PR is merged):
- revert [this line](https://github.com/terraform-google-modules/terraform-google-container-vm/pull/41/files#diff-f0efe3b68184faf8297c86a0b0519f5dR108) to point to git source 
- enable MIG integration test in the [kitchen config](https://github.com/ivankorn/terraform-google-container-vm/blob/28/.kitchen.yml)