### PR TITLE
Fix regression in cos-mysql `kms_data` variable introduced in #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+## [1.0.3] - 2019-10-12
+
+### Fixed
+
+- Fix regression in cos-mysql `kms_data` variable introduced in [#31]. [#46]
+
 ## [1.0.2] - 2019-10-11
 
 ### Fixed
@@ -56,6 +62,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 - This is the initial release of the Container VM module.
 
 [Unreleased]: https://github.com/terraform-google-modules/terraform-google-container-vm/compare/v1.0.2...HEAD
+[1.0.3]: https://github.com/terraform-google-modules/terraform-google-container-vm/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/terraform-google-modules/terraform-google-container-vm/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/terraform-google-modules/terraform-google-container-vm/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/terraform-google-modules/terraform-google-container-vm/compare/v0.3.0...v1.0.0
@@ -63,6 +70,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [0.2.0]: https://github.com/terraform-google-modules/terraform-google-container-vm/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/terraform-google-modules/terraform-google-container-vm/compare/v0.1.0...v0.1.1
 
+[#46]: https://github.com/terraform-google-modules/terraform-google-container-vm/pull/46
 [#41]: https://github.com/terraform-google-modules/terraform-google-container-vm/pull/41
 [#39]: https://github.com/terraform-google-modules/terraform-google-container-vm/pull/39
 [#31]: https://github.com/terraform-google-modules/terraform-google-container-vm/pull/31

--- a/modules/cos-mysql/README.md
+++ b/modules/cos-mysql/README.md
@@ -56,7 +56,7 @@ module "mysql" {
 | host\_project\_id | VPC host project id if the instance is in a service project. | string | `""` | no |
 | instance\_count | Number of instances to create. | number | `"1"` | no |
 | instance\_type | Instance machine type. | string | `"n1-standard-2"` | no |
-| kms\_data | Map with KMS project_id, keyring, location and key if password is encrypted with KMS. | object | `"null"` | no |
+| kms\_data | Map with KMS project_id, keyring, location and key if password is encrypted with KMS. | map(string) | `<map>` | no |
 | labels | Labels to be attached to the resources | map(string) | `<map>` | no |
 | log\_driver | Docker log driver to use for CoreDNS. | string | `"gcplogs"` | no |
 | my\_cnf | Content of the my.cnf file that will be written on the instances. | string | `""` | no |

--- a/modules/cos-mysql/variables.tf
+++ b/modules/cos-mysql/variables.tf
@@ -109,7 +109,7 @@ variable "my_cnf" {
 
 variable "kms_data" {
   description = "Map with KMS project_id, keyring, location and key if password is encrypted with KMS."
-  type        = object({ key = string, keyring = string, location = string, project_id = string })
+  type        = map(string)
   default     = null
 }
 

--- a/modules/cos-mysql/variables.tf
+++ b/modules/cos-mysql/variables.tf
@@ -109,7 +109,7 @@ variable "my_cnf" {
 
 variable "kms_data" {
   description = "Map with KMS project_id, keyring, location and key if password is encrypted with KMS."
-  type        = object({ key = string, keyring = string, location = string })
+  type        = object({ key = string, keyring = string, location = string, project_id = string })
   default     = null
 }
 


### PR DESCRIPTION
Setting types on the `cos_mysql` submodule variables was done incorrectly, with `kms_data` missing a member and KMS becoming unusable in the module. This fixes it by only setting the type declaration to a generic string map, so that all members can be passed in, and the variable is optional (as it should be when no password decryption is required).