### PR TITLE
Fix default value of kms_data in cos-mysql submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix default value of `kms_data` in `cos-mysql` submodule
+
 ## [1.0.3] - 2019-10-12
 
 ### Fixed

--- a/modules/cos-mysql/variables.tf
+++ b/modules/cos-mysql/variables.tf
@@ -110,7 +110,7 @@ variable "my_cnf" {
 variable "kms_data" {
   description = "Map with KMS project_id, keyring, location and key if password is encrypted with KMS."
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "password" {


### PR DESCRIPTION
Slipped in a wrong default in #46 this fixes it.