### PR TITLE
Add container outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ Then perform the following commands on the root folder:
 | Name | Description |
 |------|-------------|
 | container | The container definition provided |
+| container\_vm | The complete container VM image object to use for the GCE instance |
 | metadata\_key | The key to assign `metadata_value` to, so container information is attached to the instance |
 | metadata\_value | The generated container configuration |
 | restart\_policy | The restart policy provided |
 | source\_image | The self_link to the COS image to use for the GCE instance. Equivalent to container_vm.self_link |
-| container\_vm | The complete container VM image object to use for the GCE instance |
 | vm\_container\_label | The COS version to deploy to the instance. To be used as the value for the `vm_container_label_key` label key. Equivalent to container_vm.name |
 | vm\_container\_label\_key | The label key for the COS version deployed to the instance |
 | volumes | The volume definition provided |

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Then perform the following commands on the root folder:
 | metadata\_key | The key to assign `metadata_value` to, so container information is attached to the instance |
 | metadata\_value | The generated container configuration |
 | restart\_policy | The restart policy provided |
-| source\_image | The COS image to use for the GCE instance |
-| vm\_container\_label | The COS version to deploy to the instance. To be used as the value for the `vm_container_label_key` label key |
+| source\_image | The self_link to the COS image to use for the GCE instance. Equivalent to container_vm.self_link |
+| container\_vm | The complete container VM image object to use for the GCE instance |
+| vm\_container\_label | The COS version to deploy to the instance. To be used as the value for the `vm_container_label_key` label key. Equivalent to container_vm.name |
 | vm\_container\_label\_key | The label key for the COS version deployed to the instance |
 | volumes | The volume definition provided |
 

--- a/output.tf
+++ b/output.tf
@@ -25,7 +25,7 @@ output "metadata_value" {
 }
 
 output "source_image" {
-  description = "The COS image to use for the GCE instance"
+  description = "The self_link to the COS image to use for the GCE instance. Equivalent to container_vm.self_link"
   value       = data.google_compute_image.coreos.self_link
 }
 
@@ -35,8 +35,13 @@ output "vm_container_label_key" {
 }
 
 output "vm_container_label" {
-  description = "The COS version to deploy to the instance. To be used as the value for the `vm_container_label_key` label key"
+  description = "The COS version to deploy to the instance. To be used as the value for the `vm_container_label_key` label key. Equivalent to container_vm.name"
   value       = data.google_compute_image.coreos.name
+}
+
+output "container_vm" {
+  description = "The complete container VM image object to use for the GCE instance"
+  value       = data.google_compute_image.coreos
 }
 
 output "container" {


### PR DESCRIPTION
Add `container_vm` to output, corresponding to the `vm_container_*` outputs.
- fixes #61 