### PR TITLE
use random_password instead of random_id for secrets

### DIFF
--- a/modules/cos-mysql/main.tf
+++ b/modules/cos-mysql/main.tf
@@ -16,15 +16,16 @@
 
 locals {
   net_project_id = var.host_project_id != "" ? var.host_project_id : var.project_id
-  password       = var.password != "" ? var.password : random_id.password.b64_url
+  password       = var.password != "" ? var.password : random_password.password.result
   prefix         = var.prefix == "" ? "" : "${var.prefix}-"
   use_kms        = var.password != "" && length(var.kms_data) == 4
 }
 
 # optional resources
 
-resource "random_id" "password" {
-  byte_length = 8
+resource "random_password" "password" {
+  length  = 32
+  special = false
 }
 
 resource "google_compute_address" "addresses" {


### PR DESCRIPTION
- random_id byte_length = 8 (integers) contains 26.6 bits of
  entropy. base64 encoding does not change that entropy.
  Instead use random_password length = 32 restricted to (upper,
  lower, int) which contains 190.5 bits of entropy.
- Restrict random_password to special = false to prevent issues
  with allowed characters.