### PR TITLE
SEC-88: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require DevOps review for any changes to GitHub Actions workflows,
+# including Dependabot-opened PRs bumping pinned action versions/SHAs.
+/.github/workflows/ @radix-health/devops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# DEVOPS-208: org-wide Dependabot github-actions rollout. Safe on every
+# repo regardless of package-registry setup -- this ecosystem only bumps
+# `uses: action@vX` references in .github/workflows/*.yml, no registry
+# credentials needed.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
     name: 'lint'
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803' # v6
       - id: variables
         run: |
           MAKEFILE=$(find . -name Makefile -print -quit)
@@ -56,11 +56,11 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.repository_owner == 'GoogleCloudPlatform' || github.repository_owner == 'terraform-google-modules'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'


### PR DESCRIPTION
## What
Pins every `uses:` reference in `.github/workflows/*.yml` to a full 40-character commit SHA, keeping the original tag/branch as a trailing comment (e.g. `actions/checkout@<sha> # v7`), matching [GitHub's recommended pattern](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Why
A mutable tag (or branch) can be repointed at any time by the upstream maintainer — or an attacker who compromises that repo — with no signal to consumers (see the `tj-actions/changed-files` compromise). SHA pins close that off.

This is also what makes the `github-actions` Dependabot ecosystem (enabled here via DEVOPS-208) actually functional: Dependabot's update mechanism is "open a PR bumping the pinned ref" — on a tag-pinned workflow there's nothing to bump, so the ecosystem was previously a no-op in this repo.

Part of [SEC-88](https://linear.app/pivotal-health/issue/SEC-88/migrate-github-actions-from-mutable-tags-to-pinned-commit-shas) — same pattern validated in the `platform-test` pilot ([platform-test#29](https://github.com/radix-health/platform-test/pull/29)).

## Note
Internal `radix-health/github_actions/...@main` refs (if present) are pinned to a SHA too. Since that repo has no version tags yet, Dependabot can't auto-bump these — re-pinning will need to be manual until `github_actions` starts cutting releases (tracked as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)